### PR TITLE
Configure debug build to work alongside release build

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,6 +19,9 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
         debug {
+            applicationIdSuffix '.debug'
+            versionNameSuffix ' DEBUG'
+
             minifyEnabled false
             useProguard false
         }

--- a/app/src/debug/res/values/strings.xml
+++ b/app/src/debug/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name" translatable="false">LISTEN.moe DEBUG</string>
+</resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">LISTEN.moe</string>
+    <string name="app_name" translatable="false">LISTEN.moe</string>
 
     <!-- Actions (notification, dialogs) -->
     <string name="action_play">Play</string>


### PR DESCRIPTION
This allows for both the debug build (built via Android Studio) and the release build (installed via the Play Store) to be installed, for easier comparisons during development.